### PR TITLE
fix setrecording for g3 cameras

### DIFF
--- a/library/protectapi.js
+++ b/library/protectapi.js
@@ -345,14 +345,17 @@ class ProtectAPI {
                     const recordingSettings = cameraInfo.recordingSettings;
                     const channels = cameraInfo.channels;
                     const smartDetectSettings = cameraInfo.smartDetectSettings;
-
                     recordingSettings.mode = mode;
 
                     const params = {
                         channels,
-                        recordingSettings,
-                        smartDetectSettings,
+                        recordingSettings
                     };
+
+                    // Only add smartDetectSettings when the camera supports it
+                    if (cameraInfo.featureFlags.hasSmartDetect) {
+                        params['smartDetectSettings'] = smartDetectSettings;
+                    }
 
                     return this.webclient.patch(`cameras/${camera.id}`, params)
                         .then(() => resolve('Recording mode successfully set.'))


### PR DESCRIPTION
The setRecordingMode call failed on the G3 Flex and G3 Instant when adding the `smartDetectSettings` parameters.
Now made it dependant on `featureFlags.hasSmartDetect`.

As I only have G3 cameras (without smartDetect) I haven't tested what happens on the other cameras.